### PR TITLE
NLPLAB-3258 make 'appuser' sudo-er

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,17 @@
-FROM amazonlinux
+FROM docker.io/library/amazonlinux:latest
 
 MAINTAINER Slava Andreyev <sandreyev@ets.org>
 
 RUN yum update -y \
-    && yum install -y procps-ng shadow-utils \
+    && yum install -y procps-ng shadow-utils sudo \
                       bzip2 curl git hostname iproute tar unzip wget which \
     && yum clean all
 
 RUN useradd appuser \
+    && usermod -aG wheel appuser \
+    && mkdir -p /etc/sudoers.d \
+    && bash -c 'echo "appuser  ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/appuser' \
+    && ls -la /etc/sudoers.d/ \
     && printf "appuser:%s\n" "$(uuidgen)" | chpasswd \
     && rm -f /etc/localtime \
     && ln -s /usr/share/zoneinfo/America/New_York /etc/localtime \


### PR DESCRIPTION
This PR makes 'appuser'  be sudo-er. This part of the docker building process got lost somehow when the code had been moved from gitlab to github.