### PR TITLE
use mamba instead of conda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,17 +24,16 @@ WORKDIR /apps
 USER appuser
 
 RUN : install miniconda and put it in PATH \
-    && curl https://repo.anaconda.com/miniconda/Miniconda3-py39_4.9.2-Linux-x86_64.sh > miniconda.sh \
-    && bash miniconda.sh -b -p miniconda \
-    && rm -f miniconda.sh \
+    && curl -L https://github.com/conda-forge/miniforge/releases/download/4.10.3-10/Mambaforge-4.10.3-10-Linux-x86_64.sh > miniforge.sh \
+    && bash miniforge.sh -b -p miniconda \
+    && rm -f miniforge.sh \
     && export PATH=$PWD/miniconda/bin:$PATH \
-    && conda install -y -p miniconda -c conda-forge mamba \
 
     # create storm cluster
-    && conda create -y -c ets -c conda-forge -p storm-cluster-env 'storm-cluster>=1.1.4' \
+    && mamba create -y -c ets -c conda-forge -p storm-cluster-env 'storm-cluster>=1.1.4' \
     # add mamba to storm cluster
     && export PATH=$PWD/miniconda/bin:$PATH \
-    && conda install -y -p storm-cluster-env -c conda-forge mamba \
+    && mamba install -y -p storm-cluster-env -c conda-forge mamba \
 
     # Clean up
     && rm -fr miniconda \

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 set -euo pipefail
 image_name=storm-cluster

--- a/registry_push.sh
+++ b/registry_push.sh
@@ -9,13 +9,22 @@ fi
 
 image_name=storm-cluster
 registry=docker.io/etslabs
+tag=${tag:-latest}
+
+if [[ $tag != 'latest' ]]; then
+    if podman image exists "localhost/$image_name:$tag"; then
+        : ok
+    else
+        podman tag "localhost/$image_name:latest" "localhost/$image_name:$tag"
+    fi
+fi
 
 # Tag your podman image:
 podman tag \
-       $image_name:latest \
-       $registry/$image_name:latest
+       "localhost/$image_name:$tag" \
+       "$registry/$image_name:$tag"
 
 echo "INFO: Using '$docker_login' to push new image to docker.io ..." >&2
 
 # Push your podman image to the registry:
-podman push $registry/$image_name:latest --creds=$docker_login
+podman push "$registry/$image_name:$tag" "--creds=$docker_login"

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 set -euo pipefail
 
@@ -13,4 +13,4 @@ fi
 
 podman run \
        -d --name $NAME \
-       $IMAGE bash -c "tail -f /dev/null"
+       $IMAGE bash -c "tail -f /etc/hostname"


### PR DESCRIPTION
This PR updates the docker image of "storm cluster" to use minimamba instead of miniconda to build the image.
It also should force the rebuild of the image to have it based on the latest version of AWS Linux 2 image.