### PR TITLE
NLPARCH-2302 fix backward compatibility issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ MAINTAINER Slava Andreyev <sandreyev@ets.org>
 
 RUN yum update -y \
     && yum install -y procps-ng shadow-utils sudo bzip2 findutils git \
-           hostname iproute tar unzip wget which libnsl libxcrypt-compat \
+                      hostname iproute tar unzip wget which \
+                      libnsl libxcrypt-compat glibc-langpack-en \
     && yum clean all
 
 RUN useradd appuser \


### PR DESCRIPTION
This PR adds libnsls  and a language pack for "en_US.UTF-8" encoding for backward compatibility