### PR TITLE
Create a backup of files that could be shadowed in Fargage containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,11 @@ RUN : install miniconda and put it in PATH \
     && rm -fr ~/.cache/pip \
     && rm -fr ~/.m2 ~/.lein
 
+WORKDIR /apps/storm-cluster-env
+
+# Create a backup of files that could be shadowed in Fargage containers
+RUN tar zcf backup.tar.gz conf.d storm/conf storm/log4j2
+
 # Set the working directory to user home directory
 WORKDIR /home/appuser
 


### PR DESCRIPTION
This PR adds a "backup" archive for storm configuration files that could be "shadowed" by Fargate container when working with "readonly" root file system. Any app that uses this image would be able to restore the missing configuration files.
